### PR TITLE
Fix warnings for shadowing parse-boolean, parse-double, and parse-long

### DIFF
--- a/README.org
+++ b/README.org
@@ -107,7 +107,7 @@ target/strf-<<version>>.js
 #+END_SRC
 **** [[https://github.com/clojure/clojurescript][ClojureScript]]
 #+BEGIN_SRC clojure :noweb-ref dep-cljs
-[org.clojure/clojurescript "1.11.4"]
+[org.clojure/clojurescript "1.11.54"]
 #+END_SRC
 *** Development
 **** [[https://github.com/hugoduncan/criterium][Criterium]]

--- a/src/core.org
+++ b/src/core.org
@@ -269,7 +269,7 @@
 
 #+BEGIN_SRC clojure :tangle ../babel/src/thi/ng/strf/core.cljc :noweb yes :mkdirp yes :padline no
   (ns thi.ng.strf.core
-    (:refer-clojure :exclude [float int long double format])
+    (:refer-clojure :exclude [float int long double format parse-boolean parse-double parse-long])
     (:require
      [clojure.string :as str])
     #?(:clj (:import [java.util Calendar Date Locale])))


### PR DESCRIPTION
For Clojure and ClojureScript warnings were

  WARNING: parse-long already refers to: #'clojure.core/parse-long in namespace: thi.ng.strf.core, being replaced by: #'thi.ng.strf.core/parse-long
  WARNING: parse-double already refers to: #'clojure.core/parse-double in namespace: thi.ng.strf.core, being replaced by: #'thi.ng.strf.core/parse-double
  WARNING: parse-boolean already refers to: #'clojure.core/parse-boolean in namespace: thi.ng.strf.core, being replaced by: #'thi.ng.strf.core/parse-boolean

This simply excludes those methods from core, and upgrade ClojureScript to
ensure
https://github.com/clojure/clojurescript/commit/8528937440d4c5a2c8fc86813c5a9928ab184daa
is in the underlying dependency.

Trying to keep this change as minimal as possible, but again, tests passed for both before and after this change in Clojure, but hung if I ran `lein cleantest` after cleanly compiling the Clojurescript, as something appears to be hanging running cemerick.cljs.test. 

It's not clear if it makes sense to replace the methods here with the upstream versions as they all appear to throw exceptions on certain input, or in the case of parse-boolean explicitely require the input be equal to "true" or "false". Likewise, the upstream implementation for parse-long does not include radix selection.